### PR TITLE
Enable CloudFront with custom domain and HTTPS

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -12,6 +12,9 @@ new InfraStack(app, 'EddySiteStack', {
   },
   githubRepo: 'Eddyjim/eddy-site',
   bucketName: 'eddysite',
-  importExistingBucket: true, // Bucket already exists — reference it, don't create
-  enableCloudFront: false, // Set to true when ready for CDN
+  importExistingBucket: true,
+  enableCloudFront: true,
+  domainName: 'eddyjim.com',
+  certificateArn: 'arn:aws:acm:us-east-1:030125065667:certificate/9e42a475-91e7-4743-a9cf-e091609b0019',
+  hostedZoneId: 'Z06096592PLH2V2D0UZJ8',
 });

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -3,6 +3,9 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as targets from 'aws-cdk-lib/aws-route53-targets';
 import { Construct } from 'constructs';
 
 interface EddySiteStackProps extends cdk.StackProps {
@@ -14,6 +17,12 @@ interface EddySiteStackProps extends cdk.StackProps {
   enableCloudFront?: boolean;
   /** Import an existing bucket instead of creating a new one */
   importExistingBucket?: boolean;
+  /** Custom domain name (e.g., "eddyjim.com") */
+  domainName?: string;
+  /** Existing ACM certificate ARN for the custom domain */
+  certificateArn?: string;
+  /** Existing Route53 hosted zone ID */
+  hostedZoneId?: string;
 }
 
 export class InfraStack extends cdk.Stack {
@@ -48,9 +57,14 @@ export class InfraStack extends cdk.Stack {
     }
 
     // ------------------------------------------------------------------
-    // CloudFront (optional)
+    // CloudFront (optional) with custom domain support
     // ------------------------------------------------------------------
     if (props.enableCloudFront) {
+      // Import existing ACM certificate if provided
+      const certificate = props.certificateArn
+        ? acm.Certificate.fromCertificateArn(this, 'Certificate', props.certificateArn)
+        : undefined;
+
       this.distribution = new cloudfront.Distribution(this, 'CDN', {
         defaultBehavior: {
           origin: new origins.S3StaticWebsiteOrigin(this.bucket),
@@ -58,6 +72,11 @@ export class InfraStack extends cdk.Stack {
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
         },
         defaultRootObject: 'index.html',
+        // Custom domain + SSL
+        ...(props.domainName && certificate ? {
+          domainNames: [props.domainName],
+          certificate,
+        } : {}),
         errorResponses: [
           {
             httpStatus: 404,
@@ -73,6 +92,22 @@ export class InfraStack extends cdk.Stack {
           },
         ],
       });
+
+      // Route53 A record — only touches the A record, leaves MX/TXT/CNAME intact
+      if (props.domainName && props.hostedZoneId) {
+        const zone = route53.HostedZone.fromHostedZoneAttributes(this, 'Zone', {
+          hostedZoneId: props.hostedZoneId,
+          zoneName: props.domainName,
+        });
+
+        new route53.ARecord(this, 'SiteARecord', {
+          zone,
+          target: route53.RecordTarget.fromAlias(
+            new targets.CloudFrontTarget(this.distribution),
+          ),
+          recordName: props.domainName,
+        });
+      }
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Enable CloudFront CDN distribution via CDK stack
- Connect `eddyjim.com` custom domain with existing ACM SSL certificate
- Route53 A record updated to alias CloudFront (mail MX/TXT/DKIM untouched)
- CloudFront invalidation permissions added to GitHub Actions deploy role
- CDK stack now accepts `domainName`, `certificateArn`, and `hostedZoneId` props

## Infrastructure deployed

| Resource | Value |
|----------|-------|
| CloudFront URL | https://d1ckq0r3n7l1y7.cloudfront.net |
| Custom domain | https://eddyjim.com |
| Distribution ID | E4T3N498L9G3F |

## Test plan
- [ ] Visit https://eddyjim.com — verify site loads via HTTPS
- [ ] Verify SSL certificate is valid (lock icon in browser)
- [ ] Verify mail delivery still works (MX records untouched)
- [ ] Deploy via CI/CD — verify CloudFront cache invalidation runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)